### PR TITLE
feat(rich-text-editor): DLT-2116 enable emoji searching by name and keyword

### DIFF
--- a/packages/dialtone-vue2/components/rich_text_editor/extensions/emoji/suggestion.js
+++ b/packages/dialtone-vue2/components/rich_text_editor/extensions/emoji/suggestion.js
@@ -7,19 +7,24 @@ import EmojiSuggestion from './EmojiSuggestion.vue';
 import tippy from 'tippy.js';
 import hideOnEsc from '../tippy_plugins/hide_on_esc';
 
+const suggestionLimit = 20;
+
 export default {
   items: ({ query }) => {
     if (query.length < 2) {
       return [];
     }
     const emojiList = Object.values(emojisIndexed);
-    const filteredEmoji = emojiList.filter(function (item) {
-      if (item.shortname.substring(1, item.shortname.length - 1).startsWith(query.toLowerCase())) {
-        return true;
-      }
-      return false;
-    });
-    return filteredEmoji.map(item => { return { code: item.shortname }; });
+    query = query.toLowerCase();
+
+    const filteredEmoji = emojiList
+      .filter(item => [
+        item.name,
+        item.shortname.replaceAll(':', ''),
+        ...item.keywords,
+      ].some(text => text.startsWith(query)),
+      ).splice(0, suggestionLimit);
+    return filteredEmoji.map(item => ({ code: item.shortname }));
   },
 
   command: ({ editor, range, props }) => {

--- a/packages/dialtone-vue2/components/rich_text_editor/extensions/emoji/suggestion.js
+++ b/packages/dialtone-vue2/components/rich_text_editor/extensions/emoji/suggestion.js
@@ -18,11 +18,12 @@ export default {
     query = query.toLowerCase();
 
     const filteredEmoji = emojiList
-      .filter(item => [
-        item.name,
-        item.shortname.replaceAll(':', ''),
-        ...item.keywords,
-      ].some(text => text.startsWith(query)),
+      .filter(
+        item => [
+          item.name,
+          item.shortname.replaceAll(':', ''),
+          ...item.keywords,
+        ].some(text => text.startsWith(query)),
       ).splice(0, suggestionLimit);
     return filteredEmoji.map(item => ({ code: item.shortname }));
   },

--- a/packages/dialtone-vue3/components/rich_text_editor/extensions/emoji/suggestion.js
+++ b/packages/dialtone-vue3/components/rich_text_editor/extensions/emoji/suggestion.js
@@ -8,19 +8,25 @@ import EmojiSuggestion from './EmojiSuggestion.vue';
 import tippy from 'tippy.js';
 import hideOnEsc from '../tippy_plugins/hide_on_esc';
 
+const suggestionLimit = 20;
+
 export default {
   items: ({ query }) => {
     if (query.length < 2) {
       return [];
     }
     const emojiList = Object.values(emojisIndexed);
-    const filteredEmoji = emojiList.filter(function (item) {
-      if (item.shortname.substring(1, item.shortname.length - 1).startsWith(query.toLowerCase())) {
-        return true;
-      }
-      return false;
-    });
-    return filteredEmoji.map(item => { return { code: item.shortname }; });
+    query = query.toLowerCase();
+
+    const filteredEmoji = emojiList
+      .filter(
+        item => [
+          item.name,
+          item.shortname.replaceAll(':', ''),
+          ...item.keywords,
+        ].some(text => text.startsWith(query)),
+      ).splice(0, suggestionLimit);
+    return filteredEmoji.map(item => ({ code: item.shortname }));
   },
 
   command: ({ editor, range, props }) => {


### PR DESCRIPTION
# Enable emoji searching by name and keyword

## Obligatory GIF (super important!)

![Obligatory GIF](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExNzZnc28xd2pxNmc4azBkZm0yMmU4N2gwOW5rNXV1dThsbzg3dXhvcyZlcD12MV9naWZzX3NlYXJjaCZjdD1n/26n6WywJyh39n1pBu/giphy.gif)

## :hammer_and_wrench: Type Of Change

These types will increment the version number on release:

- [x] Feature

## :book: Jira Ticket

https://dialpad.atlassian.net/browse/DLT-2116

## :book: Description

- Added the ability to search emojis through suggestion with keywords and name too.
- Added `suggestionLimit` to limit the results to 20, this hugely improves the performance.

## :bulb: Context

- Issues with message input were reported

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [ ] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all Vue changes:

- [ ] I have added / updated unit tests.
- [x] I have made my changes in Vue 2 and Vue 3. Note: you may sync your changes from Vue 2 to Vue 3 (or vice versa) using the `./scripts/dialtone-vue-sync.sh` script. Read docs here: [Dialtone Vue Sync Script](../packages/dialtone-vue3/.github/CONTRIBUTING.md#dialtone-vue-sync-script)
- [ ] I have validated components with a screen reader.
- [ ] I have validated components keyboard navigation.

## :crystal_ball: Next Steps

Release, update and test on product

## :camera: Screenshots / GIFs

<img width="1623" alt="Screenshot 2024-10-04 at 2 25 04 p m" src="https://github.com/user-attachments/assets/a6a13004-0422-4f0f-ac28-7961e743691e">
