### PR TITLE
fix(rich-text-editor): DP-113072 support dialtone emojis by setting value prop

### DIFF
--- a/packages/dialtone-vue2/components/rich_text_editor/rich_text_editor.stories.js
+++ b/packages/dialtone-vue2/components/rich_text_editor/rich_text_editor.stories.js
@@ -13,7 +13,7 @@ import slashCommandSuggestion from './slash_command_suggestion';
 
 // Default Prop Values
 export const argsData = {
-  value: '<p>I am not a standalone component, please use Message Input instead <emoji-component code=":v_tone3:"></emoji-component><emoji-component code=":robot:"></emoji-component>!</p>',
+  value: '<p>I am not a standalone component, please use Message Input instead ✌🏽🤖!</p>',
   editable: true,
   inputAriaLabel: 'This is a descriptive label',
   autoFocus: false,

--- a/packages/dialtone-vue2/components/rich_text_editor/rich_text_editor.vue
+++ b/packages/dialtone-vue2/components/rich_text_editor/rich_text_editor.vue
@@ -507,7 +507,7 @@ export default {
 
   mounted () {
     warnIfUnmounted(this.$el, this.$options.name);
-    this.processValue(this.value);
+    this.processValue(this.value, false);
   },
 
   methods: {
@@ -568,13 +568,14 @@ export default {
       this.addEditorListeners();
     },
 
-    processValue (newValue) {
+    processValue (newValue, returnIfEqual = true) {
       let currentValue = this.getOutput();
       if (this.outputFormat === 'json') {
         newValue = JSON.stringify(newValue);
         currentValue = JSON.stringify(currentValue);
       }
-      if (newValue === currentValue) {
+
+      if (returnIfEqual && newValue === currentValue) {
         // The new value came from this component and was passed back down
         // through the parent, so don't do anything here.
         return;

--- a/packages/dialtone-vue2/components/rich_text_editor/rich_text_editor.vue
+++ b/packages/dialtone-vue2/components/rich_text_editor/rich_text_editor.vue
@@ -493,18 +493,7 @@ export default {
     },
 
     value (newValue) {
-      let currentValue = this.getOutput();
-      if (this.outputFormat === 'json') {
-        newValue = JSON.stringify(newValue);
-        currentValue = JSON.stringify(currentValue);
-      }
-      if (newValue === currentValue) {
-        // The new value came from this component and was passed back down
-        // through the parent, so don't do anything here.
-        return;
-      }
-      // Otherwise replace the content (resets the cursor position).
-      this.editor.commands.setContent(newValue, false);
+      this.processValue(newValue);
     },
   },
 
@@ -518,6 +507,7 @@ export default {
 
   mounted () {
     warnIfUnmounted(this.$el, this.$options.name);
+    this.processValue(this.value);
   },
 
   methods: {
@@ -576,6 +566,26 @@ export default {
         },
       });
       this.addEditorListeners();
+    },
+
+    processValue (newValue) {
+      let currentValue = this.getOutput();
+      if (this.outputFormat === 'json') {
+        newValue = JSON.stringify(newValue);
+        currentValue = JSON.stringify(currentValue);
+      }
+      if (newValue === currentValue) {
+        // The new value came from this component and was passed back down
+        // through the parent, so don't do anything here.
+        return;
+      }
+
+      if (this.outputFormat === 'text') {
+        // If the text contains emoji characters convert them to emoji component tags
+        newValue = newValue.replace(/(\p{Emoji}\p{Emoji_Modifier}?)/gu, '<emoji-component code="$1"></emoji-component>');
+      }
+      // Otherwise replace the content (resets the cursor position).
+      this.editor.commands.setContent(newValue, false);
     },
 
     destroyEditor () {

--- a/packages/dialtone-vue2/components/rich_text_editor/rich_text_editor.vue
+++ b/packages/dialtone-vue2/components/rich_text_editor/rich_text_editor.vue
@@ -580,10 +580,9 @@ export default {
         return;
       }
 
-      if (this.outputFormat === 'text') {
-        // If the text contains emoji characters convert them to emoji component tags
-        newValue = newValue.replace(/(\p{Emoji}\p{Emoji_Modifier}?)/gu, '<emoji-component code="$1"></emoji-component>');
-      }
+      // If the text contains emoji characters convert them to emoji component tags
+      newValue = newValue.replace(/(\p{Emoji}\p{Emoji_Modifier}?)/gu, '<emoji-component code="$1"></emoji-component>');
+
       // Otherwise replace the content (resets the cursor position).
       this.editor.commands.setContent(newValue, false);
     },

--- a/packages/dialtone-vue3/components/rich_text_editor/rich_text_editor.stories.js
+++ b/packages/dialtone-vue3/components/rich_text_editor/rich_text_editor.stories.js
@@ -13,7 +13,7 @@ import slashCommandSuggestion from './slash_command_suggestion';
 
 // Default Prop Values
 export const argsData = {
-  modelValue: '<p>I am not a standalone component, please use Message Input instead <emoji-component code=":v_tone3:"></emoji-component><emoji-component code=":robot:"></emoji-component>!</p>',
+  modelValue: '<p>I am not a standalone component, please use Message Input instead ✌🏽🤖!</p>',
   editable: true,
   inputAriaLabel: 'This is a descriptive label',
   autoFocus: false,

--- a/packages/dialtone-vue3/components/rich_text_editor/rich_text_editor.vue
+++ b/packages/dialtone-vue3/components/rich_text_editor/rich_text_editor.vue
@@ -507,11 +507,7 @@ export default {
 
   mounted () {
     warnIfUnmounted(this.$el, this.$options.name);
-<<<<<<< ours
     this.processValue(this.modelValue);
-=======
-    this.processValue(this.value, false);
->>>>>>> theirs
   },
 
   methods: {
@@ -572,14 +568,13 @@ export default {
       this.addEditorListeners();
     },
 
-    processValue (newValue, returnIfEqual = true) {
+    processValue (newValue) {
       let currentValue = this.getOutput();
       if (this.outputFormat === 'json') {
         newValue = JSON.stringify(newValue);
         currentValue = JSON.stringify(currentValue);
       }
-
-      if (returnIfEqual && newValue === currentValue) {
+      if (newValue === currentValue) {
         // The new value came from this component and was passed back down
         // through the parent, so don't do anything here.
         return;

--- a/packages/dialtone-vue3/components/rich_text_editor/rich_text_editor.vue
+++ b/packages/dialtone-vue3/components/rich_text_editor/rich_text_editor.vue
@@ -580,10 +580,9 @@ export default {
         return;
       }
 
-      if (this.outputFormat === 'text') {
-        // If the text contains emoji characters convert them to emoji component tags
-        newValue = newValue.replace(/(\p{Emoji}\p{Emoji_Modifier}?)/gu, '<emoji-component code="$1"></emoji-component>');
-      }
+      // If the text contains emoji characters convert them to emoji component tags
+      newValue = newValue.replace(/(\p{Emoji}\p{Emoji_Modifier}?)/gu, '<emoji-component code="$1"></emoji-component>');
+
       // Otherwise replace the content (resets the cursor position).
       this.editor.commands.setContent(newValue, false);
     },

--- a/packages/dialtone-vue3/components/rich_text_editor/rich_text_editor.vue
+++ b/packages/dialtone-vue3/components/rich_text_editor/rich_text_editor.vue
@@ -493,18 +493,7 @@ export default {
     },
 
     modelValue (newValue) {
-      let currentValue = this.getOutput();
-      if (this.outputFormat === 'json') {
-        newValue = JSON.stringify(newValue);
-        currentValue = JSON.stringify(currentValue);
-      }
-      if (newValue === currentValue) {
-        // The new value came from this component and was passed back down
-        // through the parent, so don't do anything here.
-        return;
-      }
-      // Otherwise replace the content (resets the cursor position).
-      this.editor.commands.setContent(newValue, false);
+      this.processValue(newValue);
     },
   },
 
@@ -518,6 +507,7 @@ export default {
 
   mounted () {
     warnIfUnmounted(this.$el, this.$options.name);
+    this.processValue(this.modelValue);
   },
 
   methods: {
@@ -576,6 +566,26 @@ export default {
         },
       });
       this.addEditorListeners();
+    },
+
+    processValue (newValue) {
+      let currentValue = this.getOutput();
+      if (this.outputFormat === 'json') {
+        newValue = JSON.stringify(newValue);
+        currentValue = JSON.stringify(currentValue);
+      }
+      if (newValue === currentValue) {
+        // The new value came from this component and was passed back down
+        // through the parent, so don't do anything here.
+        return;
+      }
+
+      if (this.outputFormat === 'text') {
+        // If the text contains emoji characters convert them to emoji component tags
+        newValue = newValue.replace(/(\p{Emoji}\p{Emoji_Modifier}?)/gu, '<emoji-component code="$1"></emoji-component>');
+      }
+      // Otherwise replace the content (resets the cursor position).
+      this.editor.commands.setContent(newValue, false);
     },
 
     destroyEditor () {

--- a/packages/dialtone-vue3/components/rich_text_editor/rich_text_editor.vue
+++ b/packages/dialtone-vue3/components/rich_text_editor/rich_text_editor.vue
@@ -507,7 +507,7 @@ export default {
 
   mounted () {
     warnIfUnmounted(this.$el, this.$options.name);
-    this.processValue(this.modelValue);
+    this.processValue(this.modelValue, false);
   },
 
   methods: {
@@ -568,13 +568,13 @@ export default {
       this.addEditorListeners();
     },
 
-    processValue (newValue) {
+    processValue (newValue, returnIfEqual = true) {
       let currentValue = this.getOutput();
       if (this.outputFormat === 'json') {
         newValue = JSON.stringify(newValue);
         currentValue = JSON.stringify(currentValue);
       }
-      if (newValue === currentValue) {
+      if (returnIfEqual && newValue === currentValue) {
         // The new value came from this component and was passed back down
         // through the parent, so don't do anything here.
         return;

--- a/packages/dialtone-vue3/components/rich_text_editor/rich_text_editor.vue
+++ b/packages/dialtone-vue3/components/rich_text_editor/rich_text_editor.vue
@@ -507,7 +507,11 @@ export default {
 
   mounted () {
     warnIfUnmounted(this.$el, this.$options.name);
+<<<<<<< ours
     this.processValue(this.modelValue);
+=======
+    this.processValue(this.value, false);
+>>>>>>> theirs
   },
 
   methods: {
@@ -568,13 +572,14 @@ export default {
       this.addEditorListeners();
     },
 
-    processValue (newValue) {
+    processValue (newValue, returnIfEqual = true) {
       let currentValue = this.getOutput();
       if (this.outputFormat === 'json') {
         newValue = JSON.stringify(newValue);
         currentValue = JSON.stringify(currentValue);
       }
-      if (newValue === currentValue) {
+
+      if (returnIfEqual && newValue === currentValue) {
         // The new value came from this component and was passed back down
         // through the parent, so don't do anything here.
         return;


### PR DESCRIPTION
# fix(rich-text-editor): DP-113072 support dialtone emojis by setting value prop

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExOHAxZXY2dnd4N3lka3J0bHZneDRtY2ZqajJzcWhzNWJoNGsxOTVlMyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/EdealKz0LxKTGs0hYA/giphy.gif)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Fix

## :book: Jira Ticket

https://dialpad.atlassian.net/browse/DP-113072

## :book: Description

Added support to replace emoji with the TipTap supported emoji tag upon setting of the value prop.

## :bulb: Context

Bug reported in product where emojis were rendered as text rather than dialtone emoji's when updating the message input programatically.

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all Vue changes:

- [x] I have made my changes in Vue 2 and Vue 3. Note: you may sync your changes from Vue 2 to Vue 3 (or vice versa) using the `./scripts/dialtone-vue-sync.sh` script. Read docs here: [Dialtone Vue Sync Script](../packages/dialtone-vue3/.github/CONTRIBUTING.md#dialtone-vue-sync-script)

## :crystal_ball: Next Steps

Update product before next week's cut.
