### PR TITLE
fix(emoji-picker): NO-JIRA refactor fix ref reactivity in vue2

### DIFF
--- a/packages/dialtone-vue2/components/emoji_picker/modules/emoji_selector.vue
+++ b/packages/dialtone-vue2/components/emoji_picker/modules/emoji_selector.vue
@@ -148,6 +148,7 @@ export default {
 
   data () {
     return {
+      tabLabelsRefs: [],
       emojiRefs: [],
       emojiFilteredRefs: [],
       isFiltering: false,
@@ -257,7 +258,7 @@ export default {
       this.tabSetLabels?.forEach((_, index) => {
         const refKey = `tabLabelRef-${index}`;
         if (this.$refs[refKey]) {
-          this.$set(this.tabLabels, index, { ...this.tabLabels[index], ref: this.$refs[refKey] });
+          this.$set(this.tabLabelsRefs, index, { ref: this.$refs[refKey] });
         }
       });
     },
@@ -329,8 +330,7 @@ export default {
     scrollToTab: function (tabIndex, focusFirstEmoji) {
       const vm = this;
       if (focusFirstEmoji === undefined) { focusFirstEmoji = true; }
-      const tabLabel = vm.tabLabels[tabIndex - 1];
-      const tabElement = tabLabel.ref[0];
+      const tabElement = vm.tabLabelsRefs[tabIndex - 1].ref[0];
 
       vm.$nextTick(function () {
         const container = vm.$refs.listRef;


### PR DESCRIPTION
# Refactor fix ref reactivity in vue2

This is a refactor of this fix https://github.com/dialpad/dialtone/pull/512
The previous fix does not work as expected in product [DP-113081](https://dialpad.atlassian.net/browse/DP-113081), probably because the vue version (`2.6.14`).
This is not something new, I deal previously with this kind of issues.

This PR is just a refactor of the same fix, Im just doing it in a different way and this one seems to work.



[DP-113081]: https://dialpad.atlassian.net/browse/DP-113081?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ